### PR TITLE
DAWG-172: Adds parameter for dev/live environment

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -17,6 +17,9 @@ inputs:
   create-env-file:
     description: 'Whether build:env should be run to generate an env file or not. This is typically true in UIs, but false in libraries.'
     required: true
+  environment:
+    description: 'Whether the action should be run on "dev" or "live" environment'
+    required: true
 runs:
   using: "composite"
   steps:
@@ -43,7 +46,7 @@ runs:
       id: github-packages-token
       shell: bash
       run: |
-        echo "::set-output name=token::$(aws secretsmanager get-secret-value --secret-id course-authoring/"${{ github.ref == 'refs/heads/main' && 'live' || 'dev' }}"/environment | jq -r '.SecretString' | jq -r .GITHUB_PACKAGES_READ_WRITE_TOKEN)"
+        echo "::set-output name=token::$(aws secretsmanager get-secret-value --secret-id course-authoring/"${{ inputs.environment }}"/environment | jq -r '.SecretString' | jq -r .GITHUB_PACKAGES_READ_WRITE_TOKEN)"
     - name: Setup Node.js environment
       uses: actions/setup-node@v3.3.0
       with:
@@ -57,7 +60,7 @@ runs:
     - name: Create .env file
       if: inputs.create-env-file == 'true'
       shell: bash
-      run: npm run build:env-"${{ github.ref == 'refs/heads/main' && 'prod' || 'dev' }}"
+      run: npm run build:env-"${{ inputs.environment == 'live' && 'prod' || 'dev' }}"
     - name: Cache commit
       uses: actions/cache@v3
       id: restore-commit

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensesame/course-authoring-github-actions-prepare-node",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "description": "{project-description}",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Dependencies of PR

None

## Description of Changes

In Jasmine's current work on the shared authoring-suite-ux library, the runs started failing due to the new environment specification of always using 'live' in libraries (to get AWS secrets to work), but prepare-node didn't have a parameter for that and was using branch name instead. This caused secrets to not be found and build to fail (https://github.com/OpenSesame/course-authoring-library-authoring-suite-ux/runs/7010133739?check_suite_focus=true) due to live creds (in library proj) being used to try to retrieve a dev secret (in prepare-node).

This change adds a required environment parameter for consumers to use that prepare-node than uses directly rather than trying to be smart (as different consumers will have different needs/usages around environment).

This has rev'd major version of action since it is a breaking change.

## Testing
<!-- Please describe any testing you ran manually -->

[Jira Task Link](https://opensesame.atlassian.net/browse/)
